### PR TITLE
setup.py -> add O3 optimization to pybind11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ ext_modules = [
             "TKernel",
         ],
         cxx_std=17,
+        extra_compile_args = ["-O3"],
     ),
 ]
 


### PR DESCRIPTION
This MAY not be compatible with MSVC, so leaving as a PR for now.