### PR TITLE
Optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 wheelhouse
+*.stl

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ ext_modules = [
             "TKShHealing",
             "TKernel",
         ],
+        extra_compile_args=["-O3"],
         cxx_std=17,
     ),
 ]

--- a/src/tessellator/tessellator.cpp
+++ b/src/tessellator/tessellator.cpp
@@ -6,18 +6,21 @@ auto get_timer() {
 
 void stop_timer(std::chrono::time_point<std::chrono::high_resolution_clock> start, std::string message) {
     auto done = get_timer();
-    float d = (std::chrono::duration_cast<std::chrono::milliseconds>(done - start).count()) / 1000.0;
-    std::cout << std::printf("%7.2f",d) << " sec: | | | " << message << std::endl;
+    float d = (std::chrono::duration_cast<std::chrono::milliseconds>(done - start).count()) / 1000.0;    
+    std::stringstream stream;
+    stream << std::fixed << std::setprecision(3) << std::setw(8) << d;
+    std::string s = stream.str();
+    py::print(s, "sec: | | |", message);
 }
 
 void log(std::string message) {
-    std::cout << message << std::endl;
+    py::print(message);
 }
 
 template<typename T>
 void log_xyz(std::string msg, T x, T y, T z, bool endline=true) {
-    std::cout << msg << ": (" << x << ", " << y << ", " << z << ")" ;
-    if (endline) std::cout << std::endl;
+    py::print(msg, ":", "(", x, ",", y, ",", z, ")");
+    if (endline) py::print();
 }
 
 template<typename T>
@@ -274,11 +277,9 @@ MeshData tessellate(TopoDS_Shape shape, double deflection, double angular_tolera
 
         try {
             long offset = -1;
-            // long triangle_count = 0;
 
-            // long s = 0;
             for (int i = 0; i < num_faces; i++) {
-                if (debug == 2) std::cout << "face " << i << std::endl;
+                if (debug == 2) py::print("face", i);
 
                 const TopoDS_Face& topods_face = TopoDS::Face(face_map.FindKey(i+1));
 

--- a/src/tessellator/tessellator.h
+++ b/src/tessellator/tessellator.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <numeric>
 #include <chrono>
+#include <cmath>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/src/tessellator/tessellator.h
+++ b/src/tessellator/tessellator.h
@@ -55,6 +55,3 @@ struct MeshData {
     py::array_t<int> edge_types;
     py::array_t<float> obj_vertices;
 };
-
-MeshData tessellate(TopoDS_Shape shape, double deflection, double angular_tolerance, bool parallel, bool debug, bool timeit);
-

--- a/test.py
+++ b/test.py
@@ -59,20 +59,12 @@ def tess(obj, deflection, angular_tolerance, parallel):
         obj,
         deflection,
         angular_tolerance,
-        compute_faces=False,
+        compute_faces=True,
         compute_edges=True,
         parallel=parallel,
-        debug=2,
+        debug=0,
         timeit=True,
     )
-
-    t = time()
-    tr = decompose(m.triangles.reshape(-1, 3), m.triangles_per_face, True)
-    print("Reshape tessellation", int(1000 * (time() - t)), "ms")
-
-    t = time()
-    sg = decompose(m.segments.reshape(-1, 2, 3), m.segments_per_edge)
-    print("Reshape edges", int(1000 * (time() - t)), "ms")
 
     return {
         "vertices": m.vertices,
@@ -85,23 +77,31 @@ def tess(obj, deflection, angular_tolerance, parallel):
     }
 
 
-brep = False
+test_case = 2
 
-if brep:
+if test_case == 0:
     # file, acc, show = "examples/b123.brep", 0.002, True
     file, acc, show = "examples/rc.brep", 0.19, False
 
     with open(file, "rb") as f:
         obj = deserialize(f.read())
-else:
+elif test_case == 1:
     if CQ:
         obj, acc, show = cq.Workplane().box(1, 2, 3).val().wrapped, 0.002, True
     elif BD:
         obj, acc, show = bd.Box(1, 2, 3).wrapped, 0.002, True
+elif test_case == 2:
+    if BD:
+        box = bd.Box(1, 2, 3)
+        # box = bd.fillet(box.edges(), 0.3)
+        bd.export_stl(box, "box.stl")
+        box2 = bd.import_stl("box.stl")
+        obj, acc, show = box2.wrapped, 0.002, True
+    elif CQ:
+        exit(1)
 
 
 tt = time()
-
 
 mesh = tess(obj, acc, 0.3, parallel=True)
 

--- a/test.py
+++ b/test.py
@@ -21,10 +21,6 @@ except:
 from OCP.BinTools import BinTools
 from OCP.TopoDS import TopoDS_Shape
 
-# sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
-
-sys.path.append("build")
-
 from ocp_addons.tessellator import tessellate
 
 
@@ -59,7 +55,16 @@ def decompose(array, indexes, flatten=False):
 
 
 def tess(obj, deflection, angular_tolerance, parallel):
-    m = tessellate(obj, deflection, angular_tolerance, parallel, False, True)
+    m = tessellate(
+        obj,
+        deflection,
+        angular_tolerance,
+        compute_faces=False,
+        compute_edges=True,
+        parallel=parallel,
+        debug=2,
+        timeit=True,
+    )
 
     t = time()
     tr = decompose(m.triangles.reshape(-1, 3), m.triangles_per_face, True)
@@ -72,9 +77,9 @@ def tess(obj, deflection, angular_tolerance, parallel):
     return {
         "vertices": m.vertices,
         "normals": m.normals,
-        "triangles": tr,
+        "triangles": m.triangles,
         "face_types": m.face_types,
-        "edges": sg,
+        "edges": m.segments,
         "edge_types": m.edge_types,
         "obj_vertices": m.obj_vertices,
     }
@@ -104,14 +109,10 @@ mesh = tess(obj, acc, 0.3, parallel=True)
 if show:
     print("vertices:", mesh["vertices"])
     print("normals:", mesh["normals"])
-    print("triangles:")
-    for t in mesh["triangles"]:
-        print("  ", json.dumps(t.tolist()))
+    print("triangles:", mesh["triangles"])
     print("face_types:", mesh["face_types"])
     print("edge_types:", mesh["edge_types"])
-    print("edges")
-    for e in mesh["edges"]:
-        print("  ", json.dumps(e.tolist()))
+    print("edges:", mesh["edges"])
     print("obj_vertices:", mesh["obj_vertices"])
 
 print("overall:", int(1000 * (time() - tt)), "ms")


### PR DESCRIPTION
I've made lots of changes to tessellator.cpp in order to be compatible with the current Python version.
The next release of ocp_vscode/ocp_tessellate will be able to use the native tessellator as soon as ocp-addons is installed (but the native tessellator can be disabled in case of issues)
I also changed test.py to allow the test of tessellating STLs (where the tessellator needs to interpolate vertex normals and compute all triangle edges).

The native tessellator is no feature complete.